### PR TITLE
Fixes sending messages from the Android app to the Garmin watches

### DIFF
--- a/Comm Android/app/build.gradle.kts
+++ b/Comm Android/app/build.gradle.kts
@@ -30,7 +30,9 @@ android {
 
 dependencies {
     implementation("androidx.recyclerview:recyclerview:1.2.1")
-    implementation("androidx.constraintlayout:constraintlayout:2.1.3")
+    implementation("androidx.constraintlayout:constraintlayout:2.1.4")
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.5.1")
 
-    implementation("com.garmin.connectiq:monkeybrains:1.0.2")
+    implementation(files("./libs/monkeybrains-sdk-release.aar"))
+    implementation("androidx.appcompat:appcompat:1.5.1")
 }

--- a/Comm Android/app/src/main/res/values-v11/styles.xml
+++ b/Comm Android/app/src/main/res/values-v11/styles.xml
@@ -8,7 +8,7 @@
         Base application theme for API 11+. This theme completely replaces
         AppBaseTheme from res/values/styles.xml on API 11+ devices.
     -->
-    <style name="AppBaseTheme" parent="android:Theme.Holo.Light">
+    <style name="AppBaseTheme" parent="Theme.AppCompat.Light">
         <!-- API 11 theme customizations can go here. -->
     </style>
 

--- a/Comm Android/app/src/main/res/values-v14/styles.xml
+++ b/Comm Android/app/src/main/res/values-v14/styles.xml
@@ -9,7 +9,7 @@
         AppBaseTheme from BOTH res/values/styles.xml and
         res/values-v11/styles.xml on API 14+ devices.
     -->
-    <style name="AppBaseTheme" parent="android:Theme.Holo.Light.DarkActionBar">
+    <style name="AppBaseTheme" parent="Theme.AppCompat.Light.DarkActionBar">
         <!-- API 14 theme customizations can go here. -->
     </style>
 

--- a/Comm Android/app/src/main/res/values/styles.xml
+++ b/Comm Android/app/src/main/res/values/styles.xml
@@ -8,7 +8,7 @@
         Base application theme, dependent on API level. This theme is replaced
         by AppBaseTheme from res/values-vXX/styles.xml on newer devices.
     -->
-    <style name="AppBaseTheme" parent="android:Theme.Light">
+    <style name="AppBaseTheme" parent="Theme.AppCompat.Light">
         <!--
             Theme customizations available in newer API levels can go in
             res/values-vXX/styles.xml, while customizations related to

--- a/Comm Android/gradle.properties
+++ b/Comm Android/gradle.properties
@@ -10,6 +10,6 @@ android.enableJetifier=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
 # Android SDK.
-compileSdkVersion=30
+compileSdkVersion=32
 minSdkVersion=21
-targetSdkVersion=30
+targetSdkVersion=32


### PR DESCRIPTION
As described in #2, sending messages from the Android app to the Garmin watch (in my case the Connect IQ simulator) did not work and resulted in a `android.os.NetworkOnMainThreadException`. This error is caused when sending messages in the main/UI thread. I fixed it by moving the message sending to a coroutine. 

Additional changes:
- Kotlin coroutines require a scope, therefore I included the androidx lifecycle dependency, and switched the DeviceActivity to be an AppCompatActivity (otherwise the lifecycle scope did not work)
- This also required changing the themes to be AppCompat themes (the design should be equal to the previous themes), and bumping the SKD targets to 32

I tested it by setting the connection type to `ConnectIQ.IQConnectType.TETHERED` in `MainActivity.kt` here: https://github.com/garmin/connectiq-android-sdk/blob/9ea3c65d7e88a12f4de6339548fde053e4e85493/Comm%20Android/app/src/main/java/com/garmin/android/apps/connectiq/sample/comm/activities/MainActivity.kt#L95