### PR TITLE
Update the Comm Sample App to use the Maven Central artifiact

### DIFF
--- a/Comm Android/app/build.gradle.kts
+++ b/Comm Android/app/build.gradle.kts
@@ -6,15 +6,20 @@ plugins {
 val compileSdkVersion: String by project
 val minSdkVersion: String by project
 val targetSdkVersion: String by project
-val applicationId = "com.garmin.android.apps.connectiq.sample.comm"
+val packageName = "com.garmin.android.apps.connectiq.sample.comm"
+val versionCode: String by project
+val versionName: String by project
 
 android {
+    namespace = this@Build_gradle.packageName
     compileSdk = this@Build_gradle.compileSdkVersion.toInt()
 
     defaultConfig {
-        applicationId = this@Build_gradle.applicationId
+        applicationId = this@Build_gradle.packageName
         minSdk = minSdkVersion.toInt()
         targetSdk = targetSdkVersion.toInt()
+        versionCode = this@Build_gradle.versionCode.toInt()
+        versionName = this@Build_gradle.versionName
     }
 
     buildTypes {
@@ -30,7 +35,7 @@ android {
 
 dependencies {
     implementation("androidx.recyclerview:recyclerview:1.2.1")
-    implementation("androidx.constraintlayout:constraintlayout:2.1.3")
+    implementation("androidx.constraintlayout:constraintlayout:2.1.4")
 
-    implementation("com.garmin.connectiq:monkeybrains:1.0.2")
+    implementation("com.garmin.connectiq:ciq-companion-app-sdk:2.0.1@aar")
 }

--- a/Comm Android/app/src/main/java/com/garmin/android/apps/connectiq/sample/comm/activities/DeviceActivity.kt
+++ b/Comm Android/app/src/main/java/com/garmin/android/apps/connectiq/sample/comm/activities/DeviceActivity.kt
@@ -50,7 +50,7 @@ class DeviceActivity : Activity() {
     private lateinit var myApp: IQApp
 
     private var appIsOpen = false
-    private val openAppListener = ConnectIQ.IQOpenApplicationListener { device, app, status ->
+    private val openAppListener = ConnectIQ.IQOpenApplicationListener { _, _, status ->
         Toast.makeText(applicationContext, "App Status: " + status.name, Toast.LENGTH_SHORT).show()
 
         if (status == ConnectIQ.IQOpenApplicationStatus.APP_IS_ALREADY_RUNNING) {
@@ -96,7 +96,7 @@ class DeviceActivity : Activity() {
         try {
             connectIQ.unregisterForDeviceEvents(device)
             connectIQ.unregisterForApplicationEvents(device, myApp)
-        } catch (e: InvalidStateException) {
+        } catch (_: InvalidStateException) {
         }
     }
 
@@ -106,7 +106,7 @@ class DeviceActivity : Activity() {
         // Send a message to open the app
         try {
             connectIQ.openApplication(device, myApp, openAppListener)
-        } catch (ex: Exception) {
+        } catch (_: Exception) {
         }
     }
 
@@ -125,7 +125,7 @@ class DeviceActivity : Activity() {
             } else {
                 connectIQ.openStore(STORE_APP_ID)
             }
-        } catch (ex: Exception) {
+        } catch (_: Exception) {
         }
     }
 
@@ -134,7 +134,7 @@ class DeviceActivity : Activity() {
         // in our MainActivity, there is no need to do so here, we
         // can just get a reference to the one and only instance.
         try {
-            connectIQ.registerForDeviceEvents(device) { device, status ->
+            connectIQ.registerForDeviceEvents(device) { _, status ->
                 // Since we will only get updates for this device, just display the status
                 deviceStatusView?.text = status.name
             }
@@ -147,7 +147,7 @@ class DeviceActivity : Activity() {
     // Let's register to receive messages from our application on the device.
     private fun listenByMyAppEvents() {
         try {
-            connectIQ.registerForAppEvents(device, myApp) { device, app, message, status ->
+            connectIQ.registerForAppEvents(device, myApp) { _, _, message, _ ->
                 // We know from our Comm sample widget that it will only ever send us strings, but in case
                 // we get something else, we are simply going to do a toString() on each object in the
                 // message list.
@@ -194,8 +194,8 @@ class DeviceActivity : Activity() {
                         .show()
                 }
             })
-        } catch (e1: InvalidStateException) {
-        } catch (e1: ServiceUnavailableException) {
+        } catch (_: InvalidStateException) {
+        } catch (_: ServiceUnavailableException) {
         }
     }
 
@@ -210,7 +210,7 @@ class DeviceActivity : Activity() {
 
     private fun onItemClick(message: Any) {
         try {
-            connectIQ.sendMessage(device, myApp, message) { device, app, status ->
+            connectIQ.sendMessage(device, myApp, message) { _, _, status ->
                 Toast.makeText(this@DeviceActivity, status.name, Toast.LENGTH_SHORT).show()
             }
         } catch (e: InvalidStateException) {

--- a/Comm Android/build.gradle.kts
+++ b/Comm Android/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("com.android.application") version "7.1.2" apply false
+    id("com.android.application") version "7.3.1" apply false
     id("org.jetbrains.kotlin.android") version "1.6.10" apply false
 }
 

--- a/Comm Android/gradle.properties
+++ b/Comm Android/gradle.properties
@@ -10,6 +10,9 @@ android.enableJetifier=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
 # Android SDK.
-compileSdkVersion=30
+compileSdkVersion=31
 minSdkVersion=21
 targetSdkVersion=30
+# App version
+versionCode=2
+versionName=2.0

--- a/Comm Android/gradle/wrapper/gradle-wrapper.properties
+++ b/Comm Android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Fri Mar 25 14:48:43 EET 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/README.md
+++ b/README.md
@@ -3,29 +3,32 @@
 ## Official documentation
 
 - Android Guide: [Connect IQ SDK for Android]
-- The sample is available on [GitHub].
+
+## SDK License
+
+- The license for using SDK is available at https://repository.sonatype.org/service/local/artifact/maven/redirect?r=central-proxy&g=com.garmin.connectiq&a=ciq-companion-app-sdk&v=LATEST&p=pdf
 
 ## Download
 
-#### JAR
+#### AAR
 
-Maven Central Repository: https://search.maven.org/artifact/com.garmin.connectiq/monkeybrains        
-↓ Latest JAR https://search.maven.org/remote_content?g=com.garmin.connectiq&a=monkeybrains&v=LATEST
+Maven Central Repository: https://central.sonatype.com/artifact/com.garmin.connectiq/ciq-companion-app-sdk/
+↓ Latest AAR https://repository.sonatype.org/service/local/artifact/maven/redirect?r=central-proxy&g=com.garmin.connectiq&a=ciq-companion-app-sdk&v=LATEST&p=aar
 
 #### MAVEN
 
 ```
 <dependency>          
     <groupId>com.garmin.connectiq</groupId>          
-    <artifactId>monkeybrains</artifactId>
-    <version>1.0.2</version>  
+    <artifactId>ciq-companion-app-sdk</artifactId>
+    <version>2.0.1</version>
 </dependency>
 ```   
 
 #### GRADLE
 
 ```
-implementation("com.garmin.connectiq:monkeybrains:1.0.2")
+implementation("com.garmin.connectiq:ciq-companion-app-sdk:2.0.1@aar")
 ```
 
 ## Samples
@@ -65,9 +68,9 @@ Please be sure to refer to the <a href="https://forums.garmin.com/developer/conn
 * [garmin.com]: Your one-stop place for all things Garmin.
 * [Third-Party Tutorials and Open Source Apps]: This forum thread provides links to tutorials and open source projects that developers in the our community find helpful.
 
-## Licence
+## License
 
-Samples [Licence].
+Samples [License].
 
 
 [Connect IQ Forum]: https://forums.garmin.com/developer/connect-iq/
@@ -87,6 +90,5 @@ Samples [Licence].
 
 [Connect IQ SDK for Android]: https://developer.garmin.com/connect-iq/core-topics/mobile-sdk-for-android/
 
-[GitHub]: https://github.com/garmin/connectiq-android-sdk
 [CommWatch.prg]: https://github.com/garmin/connectiq-android-sdk/blob/master/CommWatch.prg
-[Licence]: https://github.com/garmin/connectiq-android-sdk/blob/master/LICENSE.md
+[License]: https://github.com/garmin/connectiq-android-sdk/blob/master/LICENSE.md


### PR DESCRIPTION
Use the Maven Central artifiact ciq-companion-app-sdk version 2.0.1
Bump the Comm Sample App version to 2.0
Update the README.md to include the link to new license agreeement for the ciq-companion-app-sdk and correct links to Maven Central repository.